### PR TITLE
Fix build issue

### DIFF
--- a/packages/component-driver-html/src/index.ts
+++ b/packages/component-driver-html/src/index.ts
@@ -3,5 +3,5 @@ export { HTMLCheckboxGroupDriver } from './components/HTMLCheckboxGroupDriver';
 export { HTMLHiddenInputDriver } from './components/HTMLHiddenInputDriver';
 export { HTMLRadioButtonGroupDriver } from './components/HTMLRadioButtonGroupDriver';
 export { HTMLSelectDriver } from './components/HTMLSelectDriver';
-export { HTMLTextAreaDriver } from './components/HTMLTextAreaDriver';
+export { HTMLTextAreaDriver } from './components/HTMLTextareaDriver';
 export { HTMLTextInputDriver } from './components/HTMLTextInputDriver';


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #34

A misspelled TextArea file inclusion caused the build to fail