### PR TITLE
Rename testzilla to atomic-testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/tangentlin/testzilla.git"
+    "url": "https://github.com/tangentlin/atomic-testing.git"
   },
   "dependencies": {},
   "devDependencies": {

--- a/packages/component-driver-html-test/README.md
+++ b/packages/component-driver-html-test/README.md
@@ -1,1 +1,1 @@
-# @atomic-testing/react-testzilla
+# @atomic-testing/component-driver-html-test

--- a/packages/component-driver-html-test/package.json
+++ b/packages/component-driver-html-test/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/tangentlin/testzilla.git"
+    "url": "https://github.com/tangentlin/atomic-testing.git"
   },
   "dependencies": {
     "@atomic-testing/core": "workspace:*",

--- a/packages/component-driver-html/README.md
+++ b/packages/component-driver-html/README.md
@@ -1,1 +1,1 @@
-# @atomic-testing/react-testzilla
+# @atomic-testing/component-driver-html

--- a/packages/component-driver-html/package.json
+++ b/packages/component-driver-html/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/tangentlin/testzilla.git"
+    "url": "https://github.com/tangentlin/atomic-testing.git"
   },
   "dependencies": {
     "@atomic-testing/core": "workspace:*"

--- a/packages/component-driver-mui-v5-test/package.json
+++ b/packages/component-driver-mui-v5-test/package.json
@@ -29,7 +29,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/tangentlin/testzilla.git"
+    "url": "https://github.com/tangentlin/atomic-testing.git"
   },
   "dependencies": {
     "@atomic-testing/core": "workspace:*",

--- a/packages/component-driver-mui-v5/package.json
+++ b/packages/component-driver-mui-v5/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/tangentlin/testzilla.git"
+    "url": "https://github.com/tangentlin/atomic-testing.git"
   },
   "dependencies": {
     "@atomic-testing/core": "workspace:*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/tangentlin/testzilla.git"
+    "url": "https://github.com/tangentlin/atomic-testing.git"
   },
   "devDependencies": {
     "@types/css.escape": "^1.5.0",

--- a/packages/dom-core/package.json
+++ b/packages/dom-core/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/tangentlin/testzilla.git"
+    "url": "https://github.com/tangentlin/atomic-testing.git"
   },
   "dependencies": {
     "@atomic-testing/core": "workspace:*"

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atomic-testing/playwright",
   "version": "0.2.0",
-  "description": "TestZilla Playwright Adapter",
+  "description": "Atomic Testing Playwright Adapter",
   "main": "dist/index.js",
   "files": [
     "dist",
@@ -16,7 +16,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/tangentlin/testzilla.git"
+    "url": "https://github.com/tangentlin/atomic-testing.git"
   },
   "dependencies": {
     "@atomic-testing/core": "workspace:*"

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,1 +1,3 @@
-# @atomic-testing/react-testzilla
+# @atomic-testing/react
+
+Atomic testing adapter for [ReactJS](https://reactjs.org)

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/tangentlin/testzilla.git"
+    "url": "https://github.com/tangentlin/atomic-testing.git"
   },
   "dependencies": {
     "@atomic-testing/core": "workspace:*",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #36
* #35

Rename a few more testzilla signatures not caught in pull request #33